### PR TITLE
Add Raspberry Pi support

### DIFF
--- a/src/raspi-connect.js
+++ b/src/raspi-connect.js
@@ -1,0 +1,21 @@
+var exec = require('child_process').exec;
+var util = require('util');
+
+module.exports = function (config) {
+
+    return function(ap, callback) {
+
+    	var new_env = util._extend(process.env, { LANG: "en", LC_ALL: "en", LC_MESSAGES: "en"});
+
+    	var commandStr = "nmcli dev wifi connect '" + ap.ssid + "'" +
+    	    " password " + "'" + ap.password + "'" ;
+
+    	if (config.iface) {
+    	    commandStr = commandStr + " ifname " + config.iface;
+    	}
+
+    	exec(commandStr, new_env, function(err, resp) {
+    	    callback && callback(err);
+    	});
+    }
+}

--- a/src/raspi-disconnect.js
+++ b/src/raspi-disconnect.js
@@ -1,0 +1,20 @@
+var exec = require('child_process').exec;
+var util = require('util');
+
+module.exports = function (config) {
+
+    return function(callback) {
+
+    	var new_env = util._extend(process.env, { LANG: "en", LC_ALL: "en", LC_MESSAGES: "en"});
+
+    	var commandStr = "nmcli dev disconnect" ;
+
+    	if (config.iface) {
+    	    commandStr += " " + config.iface;
+    	}
+
+    	exec(commandStr, new_env, function(err, resp) {
+    	    callback && callback(err);
+    	});
+    }
+}

--- a/src/raspi-scan.js
+++ b/src/raspi-scan.js
@@ -1,0 +1,90 @@
+var exec = require('child_process').exec;
+var networkUtils = require('./network-utils');
+var util = require('util');
+
+
+function scanWifi(config) {
+
+    return function(callback) {
+
+    	var networks = [];
+    	var network = {};
+    	var new_env = util._extend(process.env, { LANG: "en", LC_ALL: "en", LC_MESSAGES: "en"});
+
+        var commandStr = "nmcli -f all -m multiline dev wifi list";
+
+        if (config.iface) {
+            commandStr += ' ifname '+config.iface;
+        }
+
+    	exec(commandStr, new_env, function(err, scanResults) {
+
+    	    if (err) {
+
+        		callback && callback(err);
+        		return;
+
+    	    }
+
+    	    var ssid = false;
+    	    var freq = false;
+    	    var signal = false;
+    	    var sec = false;
+    	    var mac = false;
+
+    	    scanResults = scanResults.toString('utf8').split(' ').join('').split('\n');
+            // console.log(scanResults);
+
+    	    for (var i = 0; i < scanResults.length; i++) {
+
+        		scanResults[i] = scanResults[i].split(":");
+        		if (scanResults[i].length == 2) {
+        		    scanResults[i][1] = scanResults[i][1].split("'").join("");
+        		}
+        		switch(scanResults[i][0]) {
+        		case 'SSID':
+        		    network.ssid = scanResults[i][1];
+        		    ssid = true;
+        		    break;
+        		case 'FREQ':
+        		    network.frequency = parseInt(scanResults[i][1]);
+        		    freq = true;
+        		    break;
+        		case 'SIGNAL':
+        		    network.signal_level = networkUtils.dBFromQuality(
+        			scanResults[i][1]);
+        		    signal = true;
+        		    break;
+        		case 'SECURITY':
+        		    network.security = scanResults[i][1];
+        		    sec = true;
+        		    break;
+        		case 'BSSID':
+        		    var macAdress = '';
+        		    for (var j = 1; j < 6; j++) {
+        			macAdress = macAdress + scanResults[i][j] + ':';
+        		    }
+        		    macAdress = macAdress + scanResults[i][6];
+        		    network.mac = macAdress;
+        		    mac = true;
+        		    break;
+        		default:
+        		    break;
+        		}
+        		if ((ssid) && (freq) && (signal) && (sec) && (mac)) {
+        		    networks.push(network);
+        		    network = {};
+        		    ssid = false;
+        		    freq = false;
+        		    signal = false;
+        		    sec = false;
+        		    mac = false;
+        		}
+    	    }
+    	    var resp = networks;
+    	    callback && callback(null, resp);
+    	});
+    }
+}
+
+exports.scanWifi = scanWifi;

--- a/src/wifi.js
+++ b/src/wifi.js
@@ -3,6 +3,9 @@ var windowsScan = require('./windows-scan.js').scanWifi;
 var linuxConnect = require('./linux-connect');
 var linuxDisconnect = require('./linux-disconnect');
 var linuxScan = require('./linux-scan.js').scanWifi;
+var raspiConnect = require('./raspi-connect');
+var raspiDisconnect = require('./raspi-disconnect');
+var raspiScan = require('./raspi-scan.js').scanWifi;
 var macConnect = require('./mac-connect.js').connectToWifi;
 var macScan = require('./mac-scan.js').scanWifi;
 
@@ -32,9 +35,18 @@ function init(options) {
 
     switch(process.platform) {
         case "linux":
-            connect = linuxConnect(config);
-            scan = linuxScan(config);
-            disconnect = linuxDisconnect(config);
+            switch(process.arch) {
+                case "arm":
+                    connect = raspiConnect(config);
+                    scan = raspiScan(config);
+                    disconnect = raspiDisconnect(config);
+                    break;
+                default:
+                    connect = linuxConnect(config);
+                    scan = linuxScan(config);
+                    disconnect = linuxDisconnect(config);
+                    break;
+            }
             break;
         case "darwin":
             connect = macConnect(config);


### PR DESCRIPTION
On my Raspberry Pi, the commands were slightly different. This switches to using special Raspberry Pi modules if `process.platform` is `"linux"` and `process.arch` is `"arm"`.

It's also possible this is simply due to a newer version of `nmcli`, so more investigation is required.